### PR TITLE
Update mukta-prod.yaml : enabling default otp

### DIFF
--- a/deploy-as-code/helm/environments/mukta-prod.yaml
+++ b/deploy-as-code/helm/environments/mukta-prod.yaml
@@ -276,7 +276,7 @@ egov-user:
   roles-state-level: "true"
   citizen-registration-withlogin: "true"
   citizen-otp-fixed: "123456"
-  citizen-otp-fixed-enabled: "false"
+  citizen-otp-fixed-enabled: "true"
   state-level-tenant-id: "od"
   java-enable-debug: true
 


### PR DESCRIPTION
enabling default OTP in order to allow playstore to test the APP.